### PR TITLE
Remove js_interop dependency.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 ## 1.3.0
 
-- Switch to dart:js_interop
-- Update SDK constraint to ">=3.3.0 <4.0.0"
+- Remove unnecessary `js_interop` dependency
+- Update Dart version to ">=3.3.0 <4.0.0"
+- Update Flutter version to ">=3.19.0"
 
 ## 1.2.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## 1.3.0
+
+- Switch to dart:js_interop
+- Update SDK constraint to ">=3.3.0 <4.0.0"
+
 ## 1.2.2
 
 - Added WASM compatibility

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,19 +1,18 @@
 name: system_date_time_format
 description: A plugin for getting date and time format patterns from device system settings.
-version: 1.2.2
+version: 1.3.0
 repository: https://github.com/Nikoro/system_date_time_format
 issue_tracker: https://github.com/Nikoro/system_date_time_format/issues
 
 environment:
-  sdk: '>=2.18.6 <4.0.0'
-  flutter: ">=2.5.0"
+  sdk: ">=3.3.0 <4.0.0"
+  flutter: ">=3.19.0"
 
 dependencies:
   flutter:
     sdk: flutter
   flutter_web_plugins:
     sdk: flutter
-  js_interop: ^0.0.1
   plugin_platform_interface: ^2.1.8
 
 dev_dependencies:


### PR DESCRIPTION
The codebase is using `dart:js_interop`, but it looks like you've accidentally included the `js_interop` dependency, as well.

This PR removes that unnecessary dependency, bumps the Dart version to 3.3.0 ([when `dart:js_interop` was introduced](https://medium.com/dartlang/dart-3-3-325bf2bf6c13)), and bumps the flutter version to 3.19.0, to [match the Dart version](https://docs.flutter.dev/release/archive).